### PR TITLE
Prevent Editor-time Prefab Error with Instantiating

### DIFF
--- a/Runtime/HelperMethods/CustomMethods.cs
+++ b/Runtime/HelperMethods/CustomMethods.cs
@@ -26,6 +26,9 @@ namespace FinishOne.GeneralUtilities
             else
             {
 #if UNITY_EDITOR
+                if (PrefabUtility.IsPartOfPrefabAsset(parent))
+                    return null;
+
                 newObject = PrefabUtility.InstantiatePrefab(original, parent) as T;
 #endif
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.finishone.general-utilities",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "displayName": "General Utilities",
   "description": "This package contains scripts shared across our projects.",
   "unity": "2022.3",


### PR DESCRIPTION
Now check that the parent we are spawning objects under at editor-time is not a prefab source